### PR TITLE
Update bigcommerce fork from Jason's branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,36 @@
+# Ruby CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-ruby/ for more details
+#
+version: 2
+jobs:
+  build:
+    docker:
+      # specify the version you desire here
+       - image: circleci/ruby:2.4.1-node-browsers
+      # Specify service dependencies here if necessary
+      # CircleCI maintains a library of pre-built images
+      # documented at https://circleci.com/docs/2.0/circleci-images/
+      # - image: circleci/postgres:9.4
+    working_directory: ~/repo
+    steps:
+      - checkout
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "Gemfile.lock" }}
+          # fallback to using the latest cache if no exact match is found
+          - v1-dependencies-
+      - run:
+          name: install dependencies
+          command: |
+            bundle install --jobs=4 --retry=3 --path vendor/bundle
+      - save_cache:
+          paths:
+            - ./vendor/bundle
+          key: v1-dependencies-{{ checksum "Gemfile.lock" }}
+      # run tests!
+      - run:
+          name: run tests
+          command: |
+            bundle exec rake

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 Changelog for nomad_client.
 
+## 0.3.1
+
+* Fixes bugs in non-GET endpoints which require body to be used instead of query params
+
 ## 0.3.0
 
 * Adds remaining endpoints according to the API documentation at https://www.nomadproject.io/api/index.html

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 Changelog for nomad_client.
 
+## 0.3.2
+* Add support for passing prefix to List Jobs endpoint.
+
 ## 0.3.1
 
 * Fixes bugs in non-GET endpoints which require body to be used instead of query params

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 Changelog for nomad_client.
 
+## 0.3.0
+
+* Adds remaining endpoints according to the API documentation at https://www.nomadproject.io/api/index.html
+
 ## 0.2.0
 
 * Adds the classes and attributes required for dealing with the deployment endpoints

--- a/lib/nomad_client/api.rb
+++ b/lib/nomad_client/api.rb
@@ -15,6 +15,7 @@ module NomadClient
     require_relative 'api/nodes'
     require_relative 'api/operator'
     require_relative 'api/regions'
+    require_relative 'api/search'
     require_relative 'api/status'
     require_relative 'api/system'
   end

--- a/lib/nomad_client/api.rb
+++ b/lib/nomad_client/api.rb
@@ -13,6 +13,7 @@ module NomadClient
     require_relative 'api/jobs'
     require_relative 'api/node'
     require_relative 'api/nodes'
+    require_relative 'api/operator'
     require_relative 'api/regions'
     require_relative 'api/status'
     require_relative 'api/system'

--- a/lib/nomad_client/api.rb
+++ b/lib/nomad_client/api.rb
@@ -18,5 +18,6 @@ module NomadClient
     require_relative 'api/search'
     require_relative 'api/status'
     require_relative 'api/system'
+    require_relative 'api/validate'
   end
 end

--- a/lib/nomad_client/api/agent.rb
+++ b/lib/nomad_client/api/agent.rb
@@ -27,7 +27,9 @@ module NomadClient
       def join(addresses)
         connection.post do |req|
           req.url "agent/join"
-          req.params[:address] = addresses
+          req.body = {
+            "address" => addresses
+          }
         end
       end
 
@@ -51,7 +53,9 @@ module NomadClient
       def force_leave(node)
         connection.post do |req|
           req.url "agent/force-leave"
-          req.params[:node] = node
+          req.body = {
+            "node" => node
+          }
         end
       end
 
@@ -75,7 +79,9 @@ module NomadClient
       def update_servers(addresses)
         connection.post do |req|
           req.url "agent/servers"
-          req.params[:address] = addresses
+          req.body = {
+            "address" => addresses
+          }
         end
       end
 

--- a/lib/nomad_client/api/client.rb
+++ b/lib/nomad_client/api/client.rb
@@ -91,14 +91,14 @@ module NomadClient
       # Note, this must be the full allocation ID, not the short 8-character one. This is specified as part of the path.
       # @param [String] task the name of the task inside the allocation to stream logs from
       # @param [Boolean] follow Whether to tail the logs
-      # @param [String] type Specifies the stream to stream
+      # @param [String] type Specifies the stream to stream (stdout | stderr)
       # @param [Integer] offset The byte offset from where content will be read
       # @param [String] origin Applies the relative offset to either the start or end of the file
       # @param [Boolean] plain Return just the plain text without framing. This can be useful when viewing logs in a browser
       # @return [Faraday::Response] A faraday response from Nomad
       def stream_logs(alloc_id, task, follow: false, type: 'stdout', offset: 0, origin: 'start', plain: false)
         connection.get do |req|
-          req.url "client/fs/stream/#{alloc_id}"
+          req.url "client/fs/logs/#{alloc_id}"
           req.params[:task]   = task
           req.params[:follow] = follow
           req.params[:type]   = type

--- a/lib/nomad_client/api/client.rb
+++ b/lib/nomad_client/api/client.rb
@@ -30,6 +30,114 @@ module NomadClient
         end
       end
 
+      ##
+      # Reads the contents of a file in an allocation directory
+      # https://www.nomadproject.io/docs/http/client-stats.html
+      #
+      # @param [String] alloc_id The allocation ID to query. This is specified as part of the URL.
+      # Note, this must be the full allocation ID, not the short 8-character one. This is specified as part of the path.
+      # @param [String] path The path of the file to read, relative to the root of the allocation directory
+      # @return [Faraday::Response] A faraday response from Nomad
+      def read_file(alloc_id, path: '/')
+        connection.get do |req|
+          req.url "client/fs/cat/#{alloc_id}"
+          req.params[:path] = path
+        end
+      end
+
+      ##
+      # Reads the contents of a file in an allocation directory at a particular offset and limit.
+      # https://www.nomadproject.io/docs/http/client-stats.html
+      #
+      # @param [String] alloc_id The allocation ID to query. This is specified as part of the URL.
+      # Note, this must be the full allocation ID, not the short 8-character one. This is specified as part of the path.
+      # @param [Integer] offset The byte offset from where content will be read
+      # @param [Integer] limit The number of bytes to read from the offset
+      # @param [String] path The path of the file to read, relative to the root of the allocation directory
+      # @return [Faraday::Response] A faraday response from Nomad
+      def read_file_at_offset(alloc_id, offset, limit, path: '/')
+        connection.get do |req|
+          req.url "client/fs/readat/#{alloc_id}"
+          req.params[:offset] = offset
+          req.params[:limit]  = limit
+          req.params[:path]   = path
+        end
+      end
+
+      ##
+      # Streams the contents of a file in an allocation directory.
+      # https://www.nomadproject.io/docs/http/client-stats.html
+      #
+      # @param [String] alloc_id The allocation ID to query. This is specified as part of the URL.
+      # Note, this must be the full allocation ID, not the short 8-character one. This is specified as part of the path.
+      # @param [Integer] offset The byte offset from where content will be read
+      # @param [String] origin Applies the relative offset to either the start or end of the file
+      # @param [String] path The path of the file to read, relative to the root of the allocation directory
+      # @return [Faraday::Response] A faraday response from Nomad
+      def stream_file(alloc_id, offset, origin: 'start', path: '/')
+        connection.get do |req|
+          req.url "client/fs/stream/#{alloc_id}"
+          req.params[:offset] = offset
+          req.params[:origin] = origin
+          req.params[:path]   = path
+        end
+      end
+
+      ##
+      # Streams a task's stderr/stdout logs
+      # https://www.nomadproject.io/docs/http/client-stats.html
+      #
+      # @param [String] alloc_id The allocation ID to query. This is specified as part of the URL.
+      # Note, this must be the full allocation ID, not the short 8-character one. This is specified as part of the path.
+      # @param [String] task the name of the task inside the allocation to stream logs from
+      # @param [Boolean] follow Whether to tail the logs
+      # @param [String] type Specifies the stream to stream
+      # @param [Integer] offset The byte offset from where content will be read
+      # @param [String] origin Applies the relative offset to either the start or end of the file
+      # @param [Boolean] plain Return just the plain text without framing. This can be useful when viewing logs in a browser
+      # @return [Faraday::Response] A faraday response from Nomad
+      def stream_logs(alloc_id, task, follow: false, type: 'stdout', offset: 0, origin: 'start', plain: false)
+        connection.get do |req|
+          req.url "client/fs/stream/#{alloc_id}"
+          req.params[:task]   = task
+          req.params[:follow] = follow
+          req.params[:type]   = type
+          req.params[:offset] = offset
+          req.params[:origin] = origin
+          req.params[:plain]  = plain
+        end
+      end
+
+      ##
+      # Lists files in an allocation directory
+      # https://www.nomadproject.io/docs/http/client-stats.html
+      #
+      # @param [String] alloc_id The allocation ID to query. This is specified as part of the URL.
+      # Note, this must be the full allocation ID, not the short 8-character one. This is specified as part of the path.
+      # @param [String] path The path of the file to read, relative to the root of the allocation directory
+      # @return [Faraday::Response] A faraday response from Nomad
+      def list_files(alloc_id, path: '/')
+        connection.get do |req|
+          req.url "client/fs/ls/#{alloc_id}"
+          req.params[:path]   = path
+        end
+      end
+
+      ##
+      # Stats a file in an allocation
+      # https://www.nomadproject.io/docs/http/client-stats.html
+      #
+      # @param [String] alloc_id The allocation ID to query. This is specified as part of the URL.
+      # Note, this must be the full allocation ID, not the short 8-character one. This is specified as part of the path.
+      # @param [String] path The path of the file to read, relative to the root of the allocation directory
+      # @return [Faraday::Response] A faraday response from Nomad
+      def stat_file(alloc_id, path: '/')
+        connection.get do |req|
+          req.url "client/fs/stat/#{alloc_id}"
+          req.params[:path]   = path
+        end
+      end
+
     end
   end
 end

--- a/lib/nomad_client/api/deployment.rb
+++ b/lib/nomad_client/api/deployment.rb
@@ -53,7 +53,9 @@ module NomadClient
       def pause(id)
         connection.post do |req|
           req.url "deployment/pause/#{id}"
-          req.params[:Pause] = true
+          req.body = {
+            "Pause" => true
+          }
         end
       end
 
@@ -66,7 +68,9 @@ module NomadClient
       def unpause(id)
         connection.post do |req|
           req.url "deployment/pause/#{id}"
-          req.params[:Pause] = false
+          req.body = {
+            "Pause" => false
+          }
         end
       end
       alias_method :resume, :unpause
@@ -82,8 +86,10 @@ module NomadClient
       def promote(id, all: false, groups: nil)
         connection.post do |req|
           req.url "deployment/promote/#{id}"
-          req.params[:All] = all
-          req.params[:Groups] = groups
+          req.body = {
+            "All" => all,
+            "Groups" => groups
+          }
         end
       end
 
@@ -100,8 +106,10 @@ module NomadClient
       def allocation_health(id, healthy_allocation_ids: nil, unhealthy_allocation_ids: nil)
         connection.post do |req|
           req.url "deployment/allocation-health/#{id}"
-          req.params[:HealthyAllocationIDs]   = healthy_allocation_ids
-          req.params[:UnhealthyAllocationIDs] = unhealthy_allocation_ids
+          req.body = {
+            "HealthyAllocationIDs" => healthy_allocation_ids,
+            "UnhealthyAllocationIDs" => unhealthy_allocation_ids
+          }
         end
       end
     end

--- a/lib/nomad_client/api/job.rb
+++ b/lib/nomad_client/api/job.rb
@@ -153,7 +153,7 @@ module NomadClient
       # @param [String] id The ID of the job according to Nomad
       # @return [Faraday::Response] A faraday response from Nomad
       def deployments(id)
-        connection.post do |req|
+        connection.get do |req|
           req.url "job/#{id}/deployments"
         end
       end
@@ -165,7 +165,7 @@ module NomadClient
       # @param [String] id The ID of the job according to Nomad
       # @return [Faraday::Response] A faraday response from Nomad
       def most_recent_deployment(id)
-        connection.post do |req|
+        connection.get do |req|
           req.url "job/#{id}/deployment"
         end
       end

--- a/lib/nomad_client/api/job.rb
+++ b/lib/nomad_client/api/job.rb
@@ -141,7 +141,7 @@ module NomadClient
       # @param [String] id The ID of the job according to Nomad
       # @return [Faraday::Response] A faraday response from Nomad
       def versions(id)
-        connection.post do |req|
+        connection.get do |req|
           req.url "job/#{id}/versions"
         end
       end

--- a/lib/nomad_client/api/job.rb
+++ b/lib/nomad_client/api/job.rb
@@ -181,8 +181,10 @@ module NomadClient
       def dispatch(id, payload: '', meta: nil)
         connection.post do |req|
           req.url "job/#{id}/dispatch"
-          req.params[:Payload] = payload
-          req.params[:Meta]    = meta
+          req.body = {
+            "Payload" => payload,
+            "Meta" => meta
+          }
         end
       end
 
@@ -198,8 +200,10 @@ module NomadClient
       def revert(id, job_version: 0, enforce_prior_version: nil)
         connection.post do |req|
           req.url "job/#{id}/revert"
-          req.params[:JobVersion]          = job_version
-          req.params[:EnforcePriorVersion] = enforce_prior_version
+          req.body = {
+            "JobVersion" => job_version,
+            "EnforcePriorVersion" => enforce_prior_version
+          }
         end
       end
 
@@ -214,8 +218,10 @@ module NomadClient
       def stable(id, job_version: 0, stable: false)
         connection.post do |req|
           req.url "job/#{id}/stable"
-          req.params[:JobVersion] = job_version
-          req.params[:Stable]     = stable
+          req.body = {
+            "JobVersion" => job_version,
+            "Stable" => stable
+          }
         end
       end
 

--- a/lib/nomad_client/api/job.rb
+++ b/lib/nomad_client/api/job.rb
@@ -134,6 +134,91 @@ module NomadClient
         end
       end
 
+      ##
+      # Reads information about all versions of a job
+      # https://www.nomadproject.io/docs/http/job.html
+      #
+      # @param [String] id The ID of the job according to Nomad
+      # @return [Faraday::Response] A faraday response from Nomad
+      def versions(id)
+        connection.post do |req|
+          req.url "job/#{id}/versions"
+        end
+      end
+
+      ##
+      # Lists a single job's deployments
+      # https://www.nomadproject.io/docs/http/job.html
+      #
+      # @param [String] id The ID of the job according to Nomad
+      # @return [Faraday::Response] A faraday response from Nomad
+      def deployments(id)
+        connection.post do |req|
+          req.url "job/#{id}/deployments"
+        end
+      end
+
+      ##
+      # Returns a single job's most recent deployment
+      # https://www.nomadproject.io/docs/http/job.html
+      #
+      # @param [String] id The ID of the job according to Nomad
+      # @return [Faraday::Response] A faraday response from Nomad
+      def most_recent_deployment(id)
+        connection.post do |req|
+          req.url "job/#{id}/deployment"
+        end
+      end
+
+      ##
+      # Dispatches a new instance of a parameterized job
+      # https://www.nomadproject.io/docs/http/job.html
+      #
+      # @param [String] id The ID of the job according to Nomad
+      # @param [String] payload Base64 encoded string containing the payload. This is limited to 15 KB
+      # @param [Hash] meta Arbitrary metadata to pass to the job
+      # @return [Faraday::Response] A faraday response from Nomad
+      def dispatch(id, payload: '', meta: nil)
+        connection.post do |req|
+          req.url "job/#{id}/dispatch"
+          req.params[:Payload] = payload
+          req.params[:Meta]    = meta
+        end
+      end
+
+      ##
+      # Reverts the job to an older version.
+      # https://www.nomadproject.io/docs/http/job.html
+      #
+      # @param [String] id The ID of the job according to Nomad
+      # @param [Integer] job_version The job version to revert to
+      # @param [Integer] enforce_prior_version Value specifying the current job's version.
+      # This is checked and acts as a check-and-set value before reverting to the specified job
+      # @return [Faraday::Response] A faraday response from Nomad
+      def revert(id, job_version: 0, enforce_prior_version: nil)
+        connection.post do |req|
+          req.url "job/#{id}/revert"
+          req.params[:JobVersion]          = job_version
+          req.params[:EnforcePriorVersion] = enforce_prior_version
+        end
+      end
+
+      ##
+      # Sets the job's stability
+      # https://www.nomadproject.io/docs/http/job.html
+      #
+      # @param [String] id The ID of the job according to Nomad
+      # @param [Integer] job_version The job version to set the stability on
+      # @param [Integer] enforce_prior_version Whether the job should be marked as stable or not
+      # @return [Faraday::Response] A faraday response from Nomad
+      def stable(id, job_version: 0, stable: false)
+        connection.post do |req|
+          req.url "job/#{id}/stable"
+          req.params[:JobVersion] = job_version
+          req.params[:Stable]     = stable
+        end
+      end
+
     end
   end
 end

--- a/lib/nomad_client/api/jobs.rb
+++ b/lib/nomad_client/api/jobs.rb
@@ -11,10 +11,12 @@ module NomadClient
       # Lists all the jobs registered with Nomad
       # https://www.nomadproject.io/docs/http/jobs.html
       #
+      # @param [String] prefix Specifies a string to filter jobs on based on an index prefix. This is specified as a querystring parameter.
       # @return [Faraday::Response] A faraday response from Nomad
-      def get
+      def get(prefix: nil)
         connection.get do |req|
           req.url "jobs"
+          req.params[:prefix] = prefix
         end
       end
 

--- a/lib/nomad_client/api/node.rb
+++ b/lib/nomad_client/api/node.rb
@@ -45,6 +45,18 @@ module NomadClient
           req.params[:enable] = enable
         end
       end
+
+      ##
+      # Creates a new evaluation for the given node. This can be used to force a run of the scheduling logic
+      # https://www.nomadproject.io/api/nodes.html
+      #
+      # @param [String] id Specifies the UUID of the node. This must be the full UUID, not the short 8-character one. This is specified as part of the path
+      # @return [Faraday::Response] A faraday response from Nomad
+      def evaluate(id)
+        connection.post do |req|
+          req.url "node/#{id}/evaluate"
+        end
+      end
     end
   end
 end

--- a/lib/nomad_client/api/node.rb
+++ b/lib/nomad_client/api/node.rb
@@ -42,7 +42,9 @@ module NomadClient
       def drain(id, enable: true)
         connection.post do |req|
           req.url "node/#{id}/drain"
-          req.params[:enable] = enable
+          req.body = {
+            "enable" => enable
+          }
         end
       end
 

--- a/lib/nomad_client/api/operator.rb
+++ b/lib/nomad_client/api/operator.rb
@@ -1,0 +1,39 @@
+module NomadClient
+  class Connection
+    def operator
+      Api::Operator.new(self)
+    end
+  end
+  module Api
+    class Operator < Path
+
+      ##
+      # Queries the status of a client node registered with Nomad
+      # https://www.nomadproject.io/api/operator.html#read-raft-configuration
+      # @param [Boolean] stale Specifies if the cluster should respond without an active leader
+      #
+      # @return [Faraday::Response] A faraday response from Nomad
+      def raft_configuration(stale: false)
+        connection.get do |req|
+          req.url "operator/raft/configuration"
+          req.params[:stale] = stale
+        end
+      end
+
+      ##
+      # removes a Nomad server with given address from the Raft configuration. The return code signifies success or failure
+      # https://www.nomadproject.io/api/operator.html#remove-raft-peer
+      # @param [Array[String]] address A list of servers to remove as [ip:port, ip:port]
+      # @param [Boolean] stale Specifies if the cluster should respond without an active leader
+      #
+      # @return [Faraday::Response] A faraday response from Nomad
+      def remove_raft_peer(address, stale: false)
+        connection.delete do |req|
+          req.url "operator/raft/peer"
+          req.params[:address] = address
+          req.params[:stale]   = stale
+        end
+      end
+    end
+  end
+end

--- a/lib/nomad_client/api/operator.rb
+++ b/lib/nomad_client/api/operator.rb
@@ -30,8 +30,10 @@ module NomadClient
       def remove_raft_peer(address, stale: false)
         connection.delete do |req|
           req.url "operator/raft/peer"
-          req.params[:address] = address
-          req.params[:stale]   = stale
+          req.body = {
+            "address" => address,
+            "stale" => stale
+          }
         end
       end
     end

--- a/lib/nomad_client/api/search.rb
+++ b/lib/nomad_client/api/search.rb
@@ -18,8 +18,10 @@ module NomadClient
       def get(prefix, context)
         connection.post do |req|
           req.url "search"
-          req.params[:Prefix]  = prefix
-          req.params[:Context] = context
+          req.body = {
+            "Prefix" => prefix,
+            "Context" => context
+          }
         end
       end
     end

--- a/lib/nomad_client/api/search.rb
+++ b/lib/nomad_client/api/search.rb
@@ -1,0 +1,27 @@
+module NomadClient
+  class Connection
+    def search
+      Api::Search.new(self)
+    end
+  end
+  module Api
+    class Search < Path
+
+      ##
+      # Returns the address of the current leader in the region
+      # https://www.nomadproject.io/api/search.html
+      # @param [String] prefix the identifer against which matches will be found. For example, if the given prefix were "a", potential matches might be "abcd", or "aabb"
+      # @param [String] context Defines the scope in which a search for a prefix operates.
+      # Contexts can be: "jobs", "evals", "allocs", "nodes", "deployment" or "all", where "all" means every context will be searched
+      #
+      # @return [Faraday::Response] A faraday response from Nomad
+      def get(prefix, context)
+        connection.post do |req|
+          req.url "search"
+          req.params[:Prefix]  = prefix
+          req.params[:Context] = context
+        end
+      end
+    end
+  end
+end

--- a/lib/nomad_client/api/validate.rb
+++ b/lib/nomad_client/api/validate.rb
@@ -1,0 +1,26 @@
+module NomadClient
+  class Connection
+    def validate
+      Api::Validate.new(self)
+    end
+  end
+  module Api
+    class Validate < Path
+
+      ##
+      # Validates a Nomad job file. The local Nomad agent forwards the request to a server.
+      # In the event a server can't be reached the agent verifies the job file locally but skips validating driver configurations
+      # https://www.nomadproject.io/api/validate.html
+      #
+      # @param [Hash|String] job A hash or json string of a valid Job payload (https://www.nomadproject.io/docs/http/job.html)
+      # @return [Faraday::Response] A faraday response from Nomad
+      def job(job)
+        connection.post do |req|
+          req.url "validate/job"
+          req.body = job
+        end
+      end
+
+    end
+  end
+end

--- a/lib/nomad_client/version.rb
+++ b/lib/nomad_client/version.rb
@@ -1,3 +1,3 @@
 module NomadClient
-  VERSION = "0.2.0"
+  VERSION = "0.3.0"
 end

--- a/lib/nomad_client/version.rb
+++ b/lib/nomad_client/version.rb
@@ -1,3 +1,3 @@
 module NomadClient
-  VERSION = "0.3.0"
+  VERSION = "0.3.1"
 end

--- a/lib/nomad_client/version.rb
+++ b/lib/nomad_client/version.rb
@@ -1,3 +1,3 @@
 module NomadClient
-  VERSION = "0.3.1"
+  VERSION = "0.3.2"
 end

--- a/spec/nomad_client/api/agent_spec.rb
+++ b/spec/nomad_client/api/agent_spec.rb
@@ -30,12 +30,10 @@ module NomadClient
 
         describe '#join' do
           it 'should call post on the join endpoint with one or more addresses' do
-            params_hash = {}
             addresses = ['http://nomad.2.local', 'http://nomad.3.local']
             expect(connection).to receive(:post).and_yield(block_receiver)
             expect(block_receiver).to receive(:url).with("agent/join")
-            expect(block_receiver).to receive(:params).and_return(params_hash)
-            expect(params_hash).to receive_message_chain(:[]=).with(:address, addresses)
+            expect(block_receiver).to receive(:body=).with({"address" => addresses})
             nomad_client.agent.join(addresses)
           end
         end
@@ -51,12 +49,10 @@ module NomadClient
 
         describe '#force_leave' do
           it 'should call post with a node name on the force-leave endpoint' do
-            params_hash = {}
             node = 'integration-3'
             expect(connection).to receive(:post).and_yield(block_receiver)
             expect(block_receiver).to receive(:url).with("agent/force-leave")
-            expect(block_receiver).to receive(:params).and_return(params_hash)
-            expect(params_hash).to receive_message_chain(:[]=).with(:node, node)
+            expect(block_receiver).to receive(:body=).with({"node" => node})
             nomad_client.agent.force_leave(node)
           end
         end
@@ -73,12 +69,10 @@ module NomadClient
 
         describe '#update_servers' do
           it 'should call post on the servers endpoint with one or more addresses' do
-            params_hash = {}
             addresses = ['http://nomad.2.local:4646', 'http://nomad.3.local:4646']
             expect(connection).to receive(:post).and_yield(block_receiver)
             expect(block_receiver).to receive(:url).with("agent/servers")
-            expect(block_receiver).to receive(:params).and_return(params_hash)
-            expect(params_hash).to receive_message_chain(:[]=).with(:address, addresses)
+            expect(block_receiver).to receive(:body=).with({"address" => addresses})
             nomad_client.agent.update_servers(addresses)
           end
         end

--- a/spec/nomad_client/api/client_spec.rb
+++ b/spec/nomad_client/api/client_spec.rb
@@ -76,17 +76,17 @@ module NomadClient
         describe '#stream_file' do
           it 'should call get on the fs/stream endpoint with the alloc id, offset, origin, and a path' do
             allocation_id    = '203266e5-e0d6-9486-5e05-397ed2b184af'
-            read_file_params = {}
+            stream_file_params = {}
             offset           = 10
             origin           = 'end'
             path             = '/file.json'
 
             expect(connection).to receive(:get).and_yield(block_receiver)
             expect(block_receiver).to receive(:url).with("client/fs/stream/#{allocation_id}")
-            allow(block_receiver).to receive(:params).and_return(read_file_params)
-            expect(read_file_params).to receive(:[]=).with(:offset, offset)
-            expect(read_file_params).to receive(:[]=).with(:origin, origin)
-            expect(read_file_params).to receive(:[]=).with(:path, path)
+            allow(block_receiver).to receive(:params).and_return(stream_file_params)
+            expect(stream_file_params).to receive(:[]=).with(:offset, offset)
+            expect(stream_file_params).to receive(:[]=).with(:origin, origin)
+            expect(stream_file_params).to receive(:[]=).with(:path, path)
 
             nomad_client.client.stream_file(allocation_id, offset, origin: origin, path: path)
           end
@@ -94,24 +94,24 @@ module NomadClient
 
         describe '#stream_logs' do
           it 'should call get on the fs/logs endpoint with the alloc_id, task, follow, type, offset, origin, and plain param' do
-            allocation_id    = '203266e5-e0d6-9486-5e05-397ed2b184af'
-            task             = 'web'
-            follow           = true
-            plain            = true
-            read_file_params = {}
-            offset           = 10
-            type             = 'stdout'
-            origin           = 'start'
+            allocation_id      = '203266e5-e0d6-9486-5e05-397ed2b184af'
+            task               = 'web'
+            follow             = true
+            plain              = true
+            stream_logs_params = {}
+            offset             = 10
+            type               = 'stdout'
+            origin             = 'start'
 
             expect(connection).to receive(:get).and_yield(block_receiver)
             expect(block_receiver).to receive(:url).with("client/fs/logs/#{allocation_id}")
-            allow(block_receiver).to receive(:params).and_return(read_file_params)
-            expect(read_file_params).to receive(:[]=).with(:task, task)
-            expect(read_file_params).to receive(:[]=).with(:follow, follow)
-            expect(read_file_params).to receive(:[]=).with(:type, type)
-            expect(read_file_params).to receive(:[]=).with(:offset, offset)
-            expect(read_file_params).to receive(:[]=).with(:origin, origin)
-            expect(read_file_params).to receive(:[]=).with(:plain, plain)
+            allow(block_receiver).to receive(:params).and_return(stream_logs_params)
+            expect(stream_logs_params).to receive(:[]=).with(:task, task)
+            expect(stream_logs_params).to receive(:[]=).with(:follow, follow)
+            expect(stream_logs_params).to receive(:[]=).with(:type, type)
+            expect(stream_logs_params).to receive(:[]=).with(:offset, offset)
+            expect(stream_logs_params).to receive(:[]=).with(:origin, origin)
+            expect(stream_logs_params).to receive(:[]=).with(:plain, plain)
 
             nomad_client.client.stream_logs(
               allocation_id,
@@ -122,6 +122,36 @@ module NomadClient
               origin: origin,
               plain: plain
             )
+          end
+        end
+
+        describe '#list_files' do
+          it 'should call get on the fs/ls endpoint with the alloc_id, and a path' do
+            allocation_id    = '203266e5-e0d6-9486-5e05-397ed2b184af'
+            path             = '/logs'
+            list_files_params = {}
+
+            expect(connection).to receive(:get).and_yield(block_receiver)
+            expect(block_receiver).to receive(:url).with("client/fs/ls/#{allocation_id}")
+            allow(block_receiver).to receive(:params).and_return(list_files_params)
+            expect(list_files_params).to receive(:[]=).with(:path, path)
+
+            nomad_client.client.list_files(allocation_id, path: path)
+          end
+        end
+
+        describe '#stat_file' do
+          it 'should call get on the fs/stat endpoint with the alloc_id, and a path' do
+            allocation_id    = '203266e5-e0d6-9486-5e05-397ed2b184af'
+            path             = '/file.json'
+            stat_file_params = {}
+
+            expect(connection).to receive(:get).and_yield(block_receiver)
+            expect(block_receiver).to receive(:url).with("client/fs/stat/#{allocation_id}")
+            allow(block_receiver).to receive(:params).and_return(stat_file_params)
+            expect(stat_file_params).to receive(:[]=).with(:path, path)
+
+            nomad_client.client.stat_file(allocation_id, path: path)
           end
         end
 

--- a/spec/nomad_client/api/client_spec.rb
+++ b/spec/nomad_client/api/client_spec.rb
@@ -39,6 +39,92 @@ module NomadClient
           end
         end
 
+        describe '#read_file' do
+          it 'should call get on the fs/cat endpoint with the alloc id and a path' do
+            allocation_id    = '203266e5-e0d6-9486-5e05-397ed2b184af'
+            read_file_params = {}
+            path             = '/file.json'
+
+            expect(connection).to receive(:get).and_yield(block_receiver)
+            expect(block_receiver).to receive(:url).with("client/fs/cat/#{allocation_id}")
+            allow(block_receiver).to receive(:params).and_return(read_file_params)
+            expect(read_file_params).to receive(:[]=).with(:path, path)
+
+            nomad_client.client.read_file(allocation_id, path: path)
+          end
+        end
+
+        describe '#read_file_at_offset' do
+          it 'should call get on the fs/readat endpoint with the alloc id, limit, offset, and a path' do
+            allocation_id    = '203266e5-e0d6-9486-5e05-397ed2b184af'
+            read_file_params = {}
+            offset           = 10
+            limit            = 100
+            path             = '/file.json'
+
+            expect(connection).to receive(:get).and_yield(block_receiver)
+            expect(block_receiver).to receive(:url).with("client/fs/readat/#{allocation_id}")
+            allow(block_receiver).to receive(:params).and_return(read_file_params)
+            expect(read_file_params).to receive(:[]=).with(:limit, limit)
+            expect(read_file_params).to receive(:[]=).with(:offset, offset)
+            expect(read_file_params).to receive(:[]=).with(:path, path)
+
+            nomad_client.client.read_file_at_offset(allocation_id, offset, limit, path: path)
+          end
+        end
+
+        describe '#stream_file' do
+          it 'should call get on the fs/stream endpoint with the alloc id, offset, origin, and a path' do
+            allocation_id    = '203266e5-e0d6-9486-5e05-397ed2b184af'
+            read_file_params = {}
+            offset           = 10
+            origin           = 'end'
+            path             = '/file.json'
+
+            expect(connection).to receive(:get).and_yield(block_receiver)
+            expect(block_receiver).to receive(:url).with("client/fs/stream/#{allocation_id}")
+            allow(block_receiver).to receive(:params).and_return(read_file_params)
+            expect(read_file_params).to receive(:[]=).with(:offset, offset)
+            expect(read_file_params).to receive(:[]=).with(:origin, origin)
+            expect(read_file_params).to receive(:[]=).with(:path, path)
+
+            nomad_client.client.stream_file(allocation_id, offset, origin: origin, path: path)
+          end
+        end
+
+        describe '#stream_logs' do
+          it 'should call get on the fs/logs endpoint with the alloc_id, task, follow, type, offset, origin, and plain param' do
+            allocation_id    = '203266e5-e0d6-9486-5e05-397ed2b184af'
+            task             = 'web'
+            follow           = true
+            plain            = true
+            read_file_params = {}
+            offset           = 10
+            type             = 'stdout'
+            origin           = 'start'
+
+            expect(connection).to receive(:get).and_yield(block_receiver)
+            expect(block_receiver).to receive(:url).with("client/fs/logs/#{allocation_id}")
+            allow(block_receiver).to receive(:params).and_return(read_file_params)
+            expect(read_file_params).to receive(:[]=).with(:task, task)
+            expect(read_file_params).to receive(:[]=).with(:follow, follow)
+            expect(read_file_params).to receive(:[]=).with(:type, type)
+            expect(read_file_params).to receive(:[]=).with(:offset, offset)
+            expect(read_file_params).to receive(:[]=).with(:origin, origin)
+            expect(read_file_params).to receive(:[]=).with(:plain, plain)
+
+            nomad_client.client.stream_logs(
+              allocation_id,
+              task,
+              follow: follow,
+              type: type,
+              offset: offset,
+              origin: origin,
+              plain: plain
+            )
+          end
+        end
+
       end
     end
   end

--- a/spec/nomad_client/api/deployment_spec.rb
+++ b/spec/nomad_client/api/deployment_spec.rb
@@ -51,11 +51,9 @@ module NomadClient
 
         describe '#pause' do
           it 'should call post with deployment_id and a pause boolean set to true on the deployment_id pause endpoint' do
-            pause_params = {}
             expect(connection).to receive(:post).and_yield(block_receiver)
             expect(block_receiver).to receive(:url).with("deployment/pause/#{deployment_id}")
-            expect(block_receiver).to receive(:params).and_return(pause_params)
-            expect(pause_params).to receive(:[]=).with(:Pause, true)
+            expect(block_receiver).to receive(:body=).with({"Pause" => true})
 
             nomad_client.deployment.pause(deployment_id)
           end
@@ -63,11 +61,9 @@ module NomadClient
 
         describe '#unpause' do
           it 'should call post with deployment_id and a pause boolean set to true on the deployment_id pause endpoint' do
-            pause_params = {}
             expect(connection).to receive(:post).and_yield(block_receiver)
             expect(block_receiver).to receive(:url).with("deployment/pause/#{deployment_id}")
-            expect(block_receiver).to receive(:params).and_return(pause_params)
-            expect(pause_params).to receive(:[]=).with(:Pause, false)
+            expect(block_receiver).to receive(:body=).with({"Pause" => false})
 
             nomad_client.deployment.unpause(deployment_id)
           end
@@ -76,25 +72,18 @@ module NomadClient
         describe '#promote' do
           context 'when promoting all' do
             it 'should call post with deployment_id and an All boolean set to true on the deployment_id promote endpoint' do
-              promote_params = {}
               expect(connection).to receive(:post).and_yield(block_receiver)
               expect(block_receiver).to receive(:url).with("deployment/promote/#{deployment_id}")
-              allow(block_receiver).to receive(:params).and_return(promote_params)
-              expect(promote_params).to receive(:[]=).with(:All, true)
-              expect(promote_params).to receive(:[]=).with(:Groups, nil)
+              expect(block_receiver).to receive(:body=).with({"All" => true, "Groups" => nil})
 
               nomad_client.deployment.promote(deployment_id, all: true)
             end
           end
           context 'when promoting a subset' do
             it 'should call post with deployment_id and an All boolean set to false and a set of groups on the deployment_id pause endpoint' do
-              promote_params = {}
               expect(connection).to receive(:post).and_yield(block_receiver)
               expect(block_receiver).to receive(:url).with("deployment/promote/#{deployment_id}")
-              allow(block_receiver).to receive(:params).and_return(promote_params)
-              expect(promote_params).to receive(:[]=).with(:All, false)
-              expect(promote_params).to receive(:[]=).with(:Groups, ['a-task-group'])
-
+              expect(block_receiver).to receive(:body=).with({"All" => false, "Groups" => ['a-task-group']})
 
               nomad_client.deployment.promote(deployment_id, all: false, groups: ['a-task-group'])
             end
@@ -105,24 +94,18 @@ module NomadClient
         describe '#allocation_health' do
           context 'when setting allocations to healthy' do
             it 'should call post with deployment_id and a set of unhealthy allocation ids on the deployment_id allocation-health endpoint' do
-              promote_params = {}
               expect(connection).to receive(:post).and_yield(block_receiver)
               expect(block_receiver).to receive(:url).with("deployment/allocation-health/#{deployment_id}")
-              allow(block_receiver).to receive(:params).and_return(promote_params)
-              expect(promote_params).to receive(:[]=).with(:HealthyAllocationIDs, ['an-allocation-id-to-set-to-healthy'])
-              expect(promote_params).to receive(:[]=).with(:UnhealthyAllocationIDs, nil)
+              expect(block_receiver).to receive(:body=).with({"HealthyAllocationIDs" => ['an-allocation-id-to-set-to-healthy'], "UnhealthyAllocationIDs" => nil})
 
               nomad_client.deployment.allocation_health(deployment_id, healthy_allocation_ids: ['an-allocation-id-to-set-to-healthy'])
             end
           end
           context 'when setting allocations to unhealthy' do
             it 'should call post with deployment_id and a set of healthy allocation ids on the deployment_id allocation-health endpoint' do
-              promote_params = {}
               expect(connection).to receive(:post).and_yield(block_receiver)
               expect(block_receiver).to receive(:url).with("deployment/allocation-health/#{deployment_id}")
-              allow(block_receiver).to receive(:params).and_return(promote_params)
-              expect(promote_params).to receive(:[]=).with(:HealthyAllocationIDs, nil)
-              expect(promote_params).to receive(:[]=).with(:UnhealthyAllocationIDs, ['an-allocation-id-to-set-to-unhealthy'])
+              expect(block_receiver).to receive(:body=).with({"HealthyAllocationIDs" => nil, "UnhealthyAllocationIDs" => ['an-allocation-id-to-set-to-unhealthy']})
 
               nomad_client.deployment.allocation_health(deployment_id, unhealthy_allocation_ids: ['an-allocation-id-to-set-to-unhealthy'])
             end

--- a/spec/nomad_client/api/job_spec.rb
+++ b/spec/nomad_client/api/job_spec.rb
@@ -158,13 +158,10 @@ module NomadClient
           it 'should call post on the dispatch endpoint with the job_id, payload, and meta hash' do
             payload         = ::Base64.encode64('some-payload')
             meta            = { 'key' => 'value' }
-            dispatch_params = {}
 
             expect(connection).to receive(:post).and_yield(block_receiver)
             expect(block_receiver).to receive(:url).with("job/#{job_id}/dispatch")
-            allow(block_receiver).to receive(:params).and_return(dispatch_params)
-            expect(dispatch_params).to receive(:[]=).with(:Payload, payload)
-            expect(dispatch_params).to receive(:[]=).with(:Meta, meta)
+            expect(block_receiver).to receive(:body=).with({"Payload" => payload, "Meta" => meta})
 
             nomad_client.job.dispatch(job_id, payload: payload, meta: meta)
           end
@@ -174,13 +171,10 @@ module NomadClient
           it 'should call post on the revert endpoint with the job_id, job_version, and an enforce_prior_version param' do
             job_version           = 1
             enforce_prior_version = true
-            revert_params         = {}
 
             expect(connection).to receive(:post).and_yield(block_receiver)
             expect(block_receiver).to receive(:url).with("job/#{job_id}/revert")
-            allow(block_receiver).to receive(:params).and_return(revert_params)
-            expect(revert_params).to receive(:[]=).with(:JobVersion, job_version)
-            expect(revert_params).to receive(:[]=).with(:EnforcePriorVersion, enforce_prior_version)
+            expect(block_receiver).to receive(:body=).with({"JobVersion" => job_version, "EnforcePriorVersion" => enforce_prior_version})
 
             nomad_client.job.revert(job_id, job_version: job_version, enforce_prior_version: enforce_prior_version)
           end
@@ -190,13 +184,10 @@ module NomadClient
           it 'should call post on the stable endpoint with the job_id, job_version, and a stable param' do
             job_version   = 2
             stable        = false
-            stable_params = {}
 
             expect(connection).to receive(:post).and_yield(block_receiver)
             expect(block_receiver).to receive(:url).with("job/#{job_id}/stable")
-            allow(block_receiver).to receive(:params).and_return(stable_params)
-            expect(stable_params).to receive(:[]=).with(:JobVersion, job_version)
-            expect(stable_params).to receive(:[]=).with(:Stable, stable)
+            expect(block_receiver).to receive(:body=).with({"JobVersion" => job_version, "Stable" => stable})
 
             nomad_client.job.stable(job_id, job_version: job_version, stable: stable)
           end

--- a/spec/nomad_client/api/job_spec.rb
+++ b/spec/nomad_client/api/job_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'base64'
 module NomadClient
   module Api
     RSpec.describe 'Job' do
@@ -116,6 +117,90 @@ module NomadClient
           end
         end
 
+        describe '#plan' do
+          it 'should call post with job_id and a job json blob on the plan endpoint' do
+            expect(connection).to receive(:post).and_yield(block_receiver)
+            expect(block_receiver).to receive(:url).with("job/#{job_id}/plan")
+            expect(block_receiver).to receive(:body=).with(nomad_job)
+
+            nomad_client.job.plan(job_id, nomad_job)
+          end
+        end
+
+        describe '#versions' do
+          it 'should call get with job_id and on the versions endpoint' do
+            expect(connection).to receive(:get).and_yield(block_receiver)
+            expect(block_receiver).to receive(:url).with("job/#{job_id}/versions")
+
+            nomad_client.job.versions(job_id)
+          end
+        end
+
+        describe '#deployments' do
+          it 'should call get with job_id and on the deployments endpoint' do
+            expect(connection).to receive(:get).and_yield(block_receiver)
+            expect(block_receiver).to receive(:url).with("job/#{job_id}/deployments")
+
+            nomad_client.job.deployments(job_id)
+          end
+        end
+
+        describe '#most_recent_deployment' do
+          it 'should call get with job_id and on the deployment endpoint' do
+            expect(connection).to receive(:get).and_yield(block_receiver)
+            expect(block_receiver).to receive(:url).with("job/#{job_id}/deployment")
+
+            nomad_client.job.most_recent_deployment(job_id)
+          end
+        end
+
+        describe '#dispatch' do
+          it 'should call post on the dispatch endpoint with the job_id, payload, and meta hash' do
+            payload         = ::Base64.encode64('some-payload')
+            meta            = { 'key' => 'value' }
+            dispatch_params = {}
+
+            expect(connection).to receive(:post).and_yield(block_receiver)
+            expect(block_receiver).to receive(:url).with("job/#{job_id}/dispatch")
+            allow(block_receiver).to receive(:params).and_return(dispatch_params)
+            expect(dispatch_params).to receive(:[]=).with(:Payload, payload)
+            expect(dispatch_params).to receive(:[]=).with(:Meta, meta)
+
+            nomad_client.job.dispatch(job_id, payload: payload, meta: meta)
+          end
+        end
+
+        describe '#revert' do
+          it 'should call post on the revert endpoint with the job_id, job_version, and an enforce_prior_version param' do
+            job_version           = 1
+            enforce_prior_version = true
+            revert_params         = {}
+
+            expect(connection).to receive(:post).and_yield(block_receiver)
+            expect(block_receiver).to receive(:url).with("job/#{job_id}/revert")
+            allow(block_receiver).to receive(:params).and_return(revert_params)
+            expect(revert_params).to receive(:[]=).with(:JobVersion, job_version)
+            expect(revert_params).to receive(:[]=).with(:EnforcePriorVersion, enforce_prior_version)
+
+            nomad_client.job.revert(job_id, job_version: job_version, enforce_prior_version: enforce_prior_version)
+          end
+        end
+
+        describe '#stable' do
+          it 'should call post on the stable endpoint with the job_id, job_version, and a stable param' do
+            job_version   = 2
+            stable        = false
+            stable_params = {}
+
+            expect(connection).to receive(:post).and_yield(block_receiver)
+            expect(block_receiver).to receive(:url).with("job/#{job_id}/stable")
+            allow(block_receiver).to receive(:params).and_return(stable_params)
+            expect(stable_params).to receive(:[]=).with(:JobVersion, job_version)
+            expect(stable_params).to receive(:[]=).with(:Stable, stable)
+
+            nomad_client.job.stable(job_id, job_version: job_version, stable: stable)
+          end
+        end
       end
     end
   end

--- a/spec/nomad_client/api/jobs_spec.rb
+++ b/spec/nomad_client/api/jobs_spec.rb
@@ -22,11 +22,26 @@ module NomadClient
         end
 
         describe '#get' do
-          it 'should call get with jobs endpoint' do
-            expect(connection).to receive(:get).and_yield(block_receiver)
-            expect(block_receiver).to receive(:url).with("jobs")
+          let(:prefix_params) { {} }
+          let(:block_receiver) { double(:block_receiver, params: prefix_params) }
+          
+          context 'with no prefix' do
+            it 'should call get on the jobs endpoint with a nil prefix' do
+              expect(connection).to receive(:get).and_yield(block_receiver)
+              expect(block_receiver).to receive(:url).with('jobs')
+              expect(prefix_params).to receive(:[]=).with(:prefix, nil)
 
-            nomad_client.jobs.get
+              nomad_client.jobs.get
+            end
+          end
+          context 'with a prefix' do
+            it 'should call get on the deployments jobs with a prefix supplied' do
+              expect(connection).to receive(:get).and_yield(block_receiver)
+              expect(block_receiver).to receive(:url).with('jobs')
+              expect(prefix_params).to receive(:[]=).with(:prefix, 'parent-job')
+
+              nomad_client.jobs.get(prefix: 'parent-job')
+            end
           end
         end
 

--- a/spec/nomad_client/api/node_spec.rb
+++ b/spec/nomad_client/api/node_spec.rb
@@ -41,21 +41,17 @@ module NomadClient
         describe '#drain' do
           context 'without supplying enable' do
             it 'should call post with a node_id and an enable flag set to true' do
-              params_hash = {}
               expect(connection).to receive(:post).and_yield(block_receiver)
               expect(block_receiver).to receive(:url).with("node/#{node_id}/drain")
-              expect(block_receiver).to receive(:params).and_return(params_hash)
-              expect(params_hash).to receive_message_chain(:[]=).with(:enable, true)
+              expect(block_receiver).to receive_message_chain(:body=).with({"enable" => true})
               nomad_client.node.drain(node_id)
             end
           end
           context 'when supplying enable' do
             it 'should call post with a node_id and an enable flag set to false' do
-              params_hash = {}
               expect(connection).to receive(:post).and_yield(block_receiver)
               expect(block_receiver).to receive(:url).with("node/#{node_id}/drain")
-              expect(block_receiver).to receive(:params).and_return(params_hash)
-              expect(params_hash).to receive_message_chain(:[]=).with(:enable, false)
+              expect(block_receiver).to receive_message_chain(:body=).with({"enable" => false})
               nomad_client.node.drain(node_id, enable: false)
             end
           end

--- a/spec/nomad_client/api/node_spec.rb
+++ b/spec/nomad_client/api/node_spec.rb
@@ -60,6 +60,15 @@ module NomadClient
             end
           end
         end
+
+        describe '#evaluate' do
+          it 'should call post with a node_id on the evaluate endpoint' do
+            expect(connection).to receive(:post).and_yield(block_receiver)
+            expect(block_receiver).to receive(:url).with("node/#{node_id}/evaluate")
+
+            nomad_client.node.evaluate(node_id)
+          end
+        end
       end
     end
   end

--- a/spec/nomad_client/api/operator_spec.rb
+++ b/spec/nomad_client/api/operator_spec.rb
@@ -6,7 +6,7 @@ module NomadClient
 
       describe 'operator' do
         it 'should add the operator method to the NomadClient::Connection class' do
-          expect(nomad_client).to respond_to :regions
+          expect(nomad_client).to respond_to :operator
           expect(nomad_client.operator).to be_kind_of NomadClient::Api::Operator
         end
       end

--- a/spec/nomad_client/api/operator_spec.rb
+++ b/spec/nomad_client/api/operator_spec.rb
@@ -35,13 +35,10 @@ module NomadClient
           it 'should call delete on the peer endpoint with an address and stale param' do
             stale = true
             address = 'https://nomad.local'
-            params_hash = {}
 
             expect(connection).to receive(:delete).and_yield(block_receiver)
             expect(block_receiver).to receive(:url).with("operator/raft/peer")
-            allow(block_receiver).to receive(:params).and_return(params_hash)
-            expect(params_hash).to receive_message_chain(:[]=).with(:address, address)
-            expect(params_hash).to receive_message_chain(:[]=).with(:stale, stale)
+            expect(block_receiver).to receive_message_chain(:body=).with({"address" => address, "stale" => stale})
             nomad_client.operator.remove_raft_peer(address, stale: stale)
           end
         end

--- a/spec/nomad_client/api/operator_spec.rb
+++ b/spec/nomad_client/api/operator_spec.rb
@@ -31,6 +31,21 @@ module NomadClient
           end
         end
 
+        describe '#remove_raft_peer' do
+          it 'should call delete on the peer endpoint with an address and stale param' do
+            stale = true
+            address = 'https://nomad.local'
+            params_hash = {}
+
+            expect(connection).to receive(:delete).and_yield(block_receiver)
+            expect(block_receiver).to receive(:url).with("operator/raft/peer")
+            allow(block_receiver).to receive(:params).and_return(params_hash)
+            expect(params_hash).to receive_message_chain(:[]=).with(:address, address)
+            expect(params_hash).to receive_message_chain(:[]=).with(:stale, stale)
+            nomad_client.operator.remove_raft_peer(address, stale: stale)
+          end
+        end
+
       end
     end
   end

--- a/spec/nomad_client/api/operator_spec.rb
+++ b/spec/nomad_client/api/operator_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+module NomadClient
+  module Api
+    RSpec.describe 'Operator' do
+      let!(:nomad_client) { NomadClient::Connection.new('http://nomad.local') }
+
+      describe 'operator' do
+        it 'should add the operator method to the NomadClient::Connection class' do
+          expect(nomad_client).to respond_to :regions
+          expect(nomad_client.operator).to be_kind_of NomadClient::Api::Operator
+        end
+      end
+
+      describe 'Operator API methods' do
+        let(:block_receiver) { double(:block_receiver) }
+        let!(:connection)    { double(:connection) }
+
+        before do
+          allow(nomad_client).to receive(:connection).and_return(connection)
+        end
+
+        describe '#raft_configuration' do
+          it 'should call get on the raft_configuration endpoint with a stale param' do
+            stale = true
+            params_hash = {}
+            expect(connection).to receive(:get).and_yield(block_receiver)
+            expect(block_receiver).to receive(:url).with("operator/raft/configuration")
+            expect(block_receiver).to receive(:params).and_return(params_hash)
+            expect(params_hash).to receive_message_chain(:[]=).with(:stale, stale)
+            nomad_client.operator.raft_configuration(stale: stale)
+          end
+        end
+
+      end
+    end
+  end
+end

--- a/spec/nomad_client/api/search_spec.rb
+++ b/spec/nomad_client/api/search_spec.rb
@@ -27,8 +27,10 @@ module NomadClient
             expect(connection).to receive(:post).and_yield(block_receiver)
             expect(block_receiver).to receive(:url).with("search")
             allow(block_receiver).to receive(:params).and_return(params_hash)
-            expect(params_hash).to receive_message_chain(:[]=).with(:Prefix, prefix)
-            expect(params_hash).to receive_message_chain(:[]=).with(:Context, context_param)
+            expect(block_receiver).to receive(:body=).with({
+              "Prefix" => prefix,
+              "Context" => context_param
+            })
             nomad_client.search.get(prefix, context_param)
           end
         end

--- a/spec/nomad_client/api/search_spec.rb
+++ b/spec/nomad_client/api/search_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+module NomadClient
+  module Api
+    RSpec.describe 'Search' do
+      let!(:nomad_client) { NomadClient::Connection.new('http://nomad.local') }
+
+      describe 'search' do
+        it 'should add the search method to the NomadClient::Connection class' do
+          expect(nomad_client).to respond_to :search
+          expect(nomad_client.search).to be_kind_of NomadClient::Api::Search
+        end
+      end
+
+      describe 'Search API methods' do
+        let(:block_receiver) { double(:block_receiver) }
+        let!(:connection)    { double(:connection) }
+
+        before do
+          allow(nomad_client).to receive(:connection).and_return(connection)
+        end
+
+        describe '#get' do
+          it 'should call get on the search endpoint with a prefix and context param' do
+            prefix        = 'mycoo'
+            context_param = 'jobs'
+            params_hash = {}
+            expect(connection).to receive(:post).and_yield(block_receiver)
+            expect(block_receiver).to receive(:url).with("search")
+            allow(block_receiver).to receive(:params).and_return(params_hash)
+            expect(params_hash).to receive_message_chain(:[]=).with(:Prefix, prefix)
+            expect(params_hash).to receive_message_chain(:[]=).with(:Context, context_param)
+            nomad_client.search.get(prefix, context_param)
+          end
+        end
+
+
+      end
+    end
+  end
+end

--- a/spec/nomad_client/api/search_spec.rb
+++ b/spec/nomad_client/api/search_spec.rb
@@ -32,8 +32,6 @@ module NomadClient
             nomad_client.search.get(prefix, context_param)
           end
         end
-
-
       end
     end
   end

--- a/spec/nomad_client/api/validate_spec.rb
+++ b/spec/nomad_client/api/validate_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+module NomadClient
+  module Api
+    RSpec.describe 'Validate' do
+      let!(:nomad_client) { NomadClient::Connection.new('http://nomad.local') }
+
+      describe 'validate' do
+        it 'should add the validate method to the NomadClient::Connection class' do
+          expect(nomad_client).to respond_to :validate
+          expect(nomad_client.validate).to be_kind_of NomadClient::Api::Validate
+        end
+      end
+
+      describe 'Validate API methods' do
+        let(:block_receiver) { double(:block_receiver) }
+        let(:nomad_job)      { { "Job" => {} } }
+        let!(:connection)    { double(:connection) }
+
+        before do
+          allow(nomad_client).to receive(:connection).and_return(connection)
+        end
+
+        describe '#job' do
+          it 'should call post on the validate job endpoint' do
+            expect(connection).to receive(:post).and_yield(block_receiver)
+            expect(block_receiver).to receive(:url).with("validate/job")
+            expect(block_receiver).to receive(:body=).with(nomad_job)
+
+            nomad_client.validate.job(nomad_job)
+          end
+        end
+
+      end
+    end
+  end
+end

--- a/spec/nomad_client/api/validate_spec.rb
+++ b/spec/nomad_client/api/validate_spec.rb
@@ -29,7 +29,6 @@ module NomadClient
             nomad_client.validate.job(nomad_job)
           end
         end
-
       end
     end
   end


### PR DESCRIPTION
Currently Launchbay relies on Jason's source of `nomad_client`. Since Jason is no longer with the company, we should instead just update our bigcommerce fork so that if Jason goes away, this isn't a problem.

This upmerges from xyzjace master into the BC fork.

----

@bigcommerce/infrastructure-engineering 