### PR TITLE
INFRA-2514 Fix deployment promotion api

### DIFF
--- a/lib/nomad_client/api/deployment.rb
+++ b/lib/nomad_client/api/deployment.rb
@@ -87,6 +87,7 @@ module NomadClient
         connection.post do |req|
           req.url "deployment/promote/#{id}"
           req.body = {
+            "DeploymentID" => id,
             "All" => all,
             "Groups" => groups
           }

--- a/spec/nomad_client/api/deployment_spec.rb
+++ b/spec/nomad_client/api/deployment_spec.rb
@@ -74,7 +74,7 @@ module NomadClient
             it 'should call post with deployment_id and an All boolean set to true on the deployment_id promote endpoint' do
               expect(connection).to receive(:post).and_yield(block_receiver)
               expect(block_receiver).to receive(:url).with("deployment/promote/#{deployment_id}")
-              expect(block_receiver).to receive(:body=).with({"All" => true, "Groups" => nil})
+              expect(block_receiver).to receive(:body=).with({"DeploymentID" => deployment_id, "All" => true, "Groups" => nil})
 
               nomad_client.deployment.promote(deployment_id, all: true)
             end
@@ -83,7 +83,7 @@ module NomadClient
             it 'should call post with deployment_id and an All boolean set to false and a set of groups on the deployment_id pause endpoint' do
               expect(connection).to receive(:post).and_yield(block_receiver)
               expect(block_receiver).to receive(:url).with("deployment/promote/#{deployment_id}")
-              expect(block_receiver).to receive(:body=).with({"All" => false, "Groups" => ['a-task-group']})
+              expect(block_receiver).to receive(:body=).with({"DeploymentID" => deployment_id, "All" => false, "Groups" => ['a-task-group']})
 
               nomad_client.deployment.promote(deployment_id, all: false, groups: ['a-task-group'])
             end


### PR DESCRIPTION
It's super dumb but `DeploymentID` is required in the request body

**Sample payload**
```
{
  "DeploymentID": "5456bd7a-9fc0-c0dd-6131-cbee77f57577",
  "All": true
}
```

https://www.nomadproject.io/api/deployments.html#sample-payload-1