### PR TITLE
INFRA-2615 Fix allocation restart endpoint

### DIFF
--- a/lib/nomad_client/api/allocation.rb
+++ b/lib/nomad_client/api/allocation.rb
@@ -27,7 +27,7 @@ module NomadClient
       # @return [Faraday::Response] A faraday response from Nomad
       def restart(id, task = nil)
         connection.post do |req|
-          req.url "allocation/#{id}/restart"
+          req.url "client/allocation/#{id}/restart"
           req.body = { 'Task' => task } unless task.nil?
         end
       end

--- a/spec/nomad_client/api/allocation_spec.rb
+++ b/spec/nomad_client/api/allocation_spec.rb
@@ -31,17 +31,17 @@ module NomadClient
 
         describe '#restart' do
           context 'task unspecified' do
-            it 'should post to allocation/:allocation_id/restart' do
+            it 'should post to client/allocation/:allocation_id/restart' do
               expect(connection).to receive(:post).and_yield(block_receiver)
-              expect(block_receiver).to receive(:url).with("allocation/#{allocation_id}/restart")
+              expect(block_receiver).to receive(:url).with("client/allocation/#{allocation_id}/restart")
 
               nomad_client.allocation.restart(allocation_id)
             end
           end
           context 'task specified' do
-            it 'should post to allocation/:allocation_id/restart with a payload' do
+            it 'should post to client/allocation/:allocation_id/restart with a payload' do
               expect(connection).to receive(:post).and_yield(block_receiver)
-              expect(block_receiver).to receive(:url).with("allocation/#{allocation_id}/restart")
+              expect(block_receiver).to receive(:url).with("client/allocation/#{allocation_id}/restart")
               expect(block_receiver).to receive(:body=).with({ 'Task' => 'foo' })
 
               nomad_client.allocation.restart(allocation_id, 'foo')


### PR DESCRIPTION
The correct endpoint to restart an allocation should be `client/allocation/:id/restart` instead of `allocation/:id/restart` .

Review please. Thanks.

Ping @bigcommerce/infrastructure-engineering 