### PR TITLE
Remove retry_change_requests for net-http-persistent 4.0 or greater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 Changelog for nomad_client.
 
+## Pending Release
+
+- Remove retry_change_requests for net-http-persistent 4.0 or greater
+
 ## 0.4.0
 
 - Add Ruby 3 support

--- a/lib/nomad_client/configuration.rb
+++ b/lib/nomad_client/configuration.rb
@@ -26,6 +26,9 @@ module NomadClient
     # net-http-persistent configuration
     attr_accessor :pool_size
     attr_accessor :idle_timeout
+    # @!attribute retry_change_requests
+    #   @return [Boolean]
+    #   @deprecated In Net::HTTP::Persistent 4.0, this functionality is deprecated
     attr_accessor :retry_change_requests
 
     DEFAULT_PORT                  = 4_646

--- a/lib/nomad_client/connection.rb
+++ b/lib/nomad_client/connection.rb
@@ -26,7 +26,7 @@ module NomadClient
         faraday.options.open_timeout = configuration.open_timeout
         faraday.adapter(:net_http_persistent, pool_size: configuration.pool_size) do |http|
           http.idle_timeout = configuration.idle_timeout
-          http.retry_change_requests = configuration.retry_change_requests
+          http.retry_change_requests = configuration.retry_change_requests if retry_change_requests_supported?
         end
       end
     end
@@ -51,6 +51,16 @@ module NomadClient
         backoff_factor: configuration.retry_backoff_factor,
         exceptions: idempotent_retryable
       }
+    end
+
+    private
+
+    ##
+    # If we're on Net::HTTP::Persistent > 4.0, we don't support retry_change_requests
+    # @return [Boolean]
+    #
+    def retry_change_requests_supported?
+      ::Gem::Version.new(Net::HTTP::Persistent::VERSION) < ::Gem::Version.new('4.0.0')
     end
   end
 end


### PR DESCRIPTION
## What?

- Bump Faraday pin to properly support Ruby 3 transitively
- Remove retry_change_requests as it is no longer supported in net-http-persistent (it's now done natively in Net::HTTP)

---

@bigcommerce/infra-engineering 